### PR TITLE
chore: Update lru-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.0",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.0.0",
+        "lru-cache": "^9.1.1",
         "minipass": "^5.0.0"
       },
       "devDependencies": {
@@ -2396,11 +2396,11 @@
       "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.0.0.tgz",
-      "integrity": "sha512-9AEKXzvOZc4BMacFnYiTOlDH/197LNnQIK9wZ6iMB5NXPzuv4bWR/Msv7iUMplkiMQ1qQL+KSv/JF1mZAB5Lrg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
       "engines": {
-        "node": ">=16.14"
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/lunr": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "url": "git+https://github.com/isaacs/path-walker"
   },
   "dependencies": {
-    "lru-cache": "^9.0.0",
+    "lru-cache": "^9.1.1",
     "minipass": "^5.0.0"
   }
 }


### PR DESCRIPTION
Hello, I have updated the `lru-cache` due to lost compatibility with Node.js 14 in v9.0.0

https://github.com/isaacs/node-lru-cache/commit/c237c1d64ebc2142da4f8324adb3ef300b0428bd