### PR TITLE
Node-prefixed requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5449,9 +5449,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "peer": true,
       "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { LRUCache } from 'lru-cache'
-import { posix, win32 } from 'path'
+import { posix, win32 } from 'node:path'
 
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
-import * as actualFS from 'fs'
+import * as actualFS from 'node:fs'
 import {
   lstatSync,
   readdir as readdirCB,
@@ -14,9 +14,9 @@ import {
 const realpathSync = rps.native
 // TODO: test perf of fs/promises realpath vs realpathCB,
 // since the promises one uses realpath.native
-import { lstat, readdir, readlink, realpath } from 'fs/promises'
+import { lstat, readdir, readlink, realpath } from 'node:fs/promises'
 
-import type { Dirent, Stats } from 'fs'
+import type { Dirent, Stats } from 'node:fs'
 import { Minipass } from 'minipass'
 
 /**


### PR DESCRIPTION
This changeset fixes and closes #16 by switching to node:-prefixed imports, which should be safe to assume support for now that Node 20 is LTS and Node 16 is EOL (Node 16 introduced this feature).

**Related issues:**
- isaacs/node-glob#580
- isaacs/minipass#54

**Peer PRs:**
- isaacs/minipass#55
- isaacs/node-glob#581